### PR TITLE
Introduce lists of groups - Sets

### DIFF
--- a/bin/gaps_server.rb
+++ b/bin/gaps_server.rb
@@ -287,6 +287,9 @@ module Gaps
         end
       end
 
+      @user.sets << set_id
+      @user.save
+
       redirect '/'
     end
 
@@ -311,10 +314,15 @@ module Gaps
       else
         set = Gaps::DB::Set.find(params[:id])
         return not_found unless set
+
+        old_groups = set.groups
+
         args.each do |key, value|
           set.send(:"#{key}=", value)
         end
         set.save
+
+        set.notify_update(old_groups)
       end
 
       redirect '/sets'

--- a/lib/gaps/db.rb
+++ b/lib/gaps/db.rb
@@ -17,6 +17,7 @@ module Gaps
     require_relative 'db/base'
     require_relative 'db/cache'
     require_relative 'db/group'
+    require_relative 'db/set'
     require_relative 'db/state'
     require_relative 'db/user'
   end

--- a/lib/gaps/db/set.rb
+++ b/lib/gaps/db/set.rb
@@ -1,0 +1,15 @@
+module Gaps::DB
+  class Set < Base
+    set_collection_name 'set'
+
+    key :name, String
+    key :description, String
+    key :groups, Array
+
+    key :deleted, Boolean, default: false
+
+    def groups_
+      group_docs = Group.find_each(_id: {:$in => self.groups}).sort_by(&:group_email)
+    end
+  end
+end

--- a/lib/gaps/db/set.rb
+++ b/lib/gaps/db/set.rb
@@ -9,7 +9,44 @@ module Gaps::DB
     key :deleted, Boolean, default: false
 
     def groups_
-      group_docs = Group.find_each(_id: {:$in => self.groups}).sort_by(&:group_email)
+      Group.find_each(_id: {:$in => self.groups}).sort_by(&:group_email)
+    end
+
+    def notify_update(old_groups)
+      added_groups = self.groups - old_groups
+      removed_groups = old_groups - self.groups
+      changed_groups = added_groups + removed_groups
+      return if changed_groups.empty?
+
+      added_group_docs, removed_group_docs =
+        Group.find_each(_id: {:$in => changed_groups}).partition {|group| added_groups.include?(group._id)}
+
+      subject = "[gaps] Update to set: #{self.name}"
+      body = "A set you've previously added has been updated.\n\n"
+
+      unless added_group_docs.empty?
+        body += "The following groups were added:\n"
+        added_group_docs.each do |group|
+          body += "  #{group.group_email}\n"
+        end
+        body += "You can subscribe to all of them at #{configatron.gaps_url}/sets\n\n"
+      end
+
+      unless removed_group_docs.empty?
+        body += "The following groups were removed:\n"
+        removed_group_docs.each do |group|
+          body += "  #{group.group_email}: #{configatron.gaps_url}/subs#lst-#{group.group_email}\n"
+        end
+      end
+
+      Gaps::DB::User.find_each(sets: {:$in => [self._id]}) do |user|
+        Gaps::Email.send_email(
+          :to => user.email,
+          :from => configatron.notify.from,
+          :subject => subject,
+          :body => body
+        )
+      end
     end
   end
 end

--- a/lib/gaps/db/user.rb
+++ b/lib/gaps/db/user.rb
@@ -24,6 +24,8 @@ module Gaps::DB
     key :alternate_emails, Array, :default => []
     key :filters, Hash, :default => {}
 
+    key :sets, Array, :default => []
+
     def self.build_index
       self.ensure_index([[:google_id, 1]], unique: true, sparse: true)
     end

--- a/views/_category_list.erb
+++ b/views/_category_list.erb
@@ -10,5 +10,3 @@
 <% end %>
 </div>
 <p> Total: <b><%= @groups.inject(0) {|count, (_, groups)| count + groups.count} %></b> lists </p>
-
-<p> You are a member of <b><%= @user.group_member_count %></b> <%= @user.group_member_count == 1 ? 'group' : 'groups' %>. </p>

--- a/views/_set_group.erb
+++ b/views/_set_group.erb
@@ -1,0 +1,13 @@
+<%
+in_set = @set ? @set.groups.include?(group._id) : false
+%>
+
+<li class="list-group-item" id='lst-<%= group.group_email %>' data-group-id='<%= group._id %>'>
+  <h4 class="list-group-item-heading">
+    <input type="checkbox" name="group[<%= group._id %>]" <% if in_set %>checked="true"<% end %> />
+    <a href="<%= group.page %>"><%= group.group_email %></a>
+  </h4>
+  <p class="list-group-item-text">
+    <%= group.description %>
+ </p>
+</li>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -11,8 +11,8 @@ quotes = [
     <title>Gaps</title>
     <!-- Bootstrap -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="css/bootstrap.min.css" rel="stylesheet" media="screen">
-    <link href="css/gaps.css" rel="stylesheet" media="screen">
+    <link href="/css/bootstrap.min.css" rel="stylesheet" media="screen">
+    <link href="/css/gaps.css" rel="stylesheet" media="screen">
 
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -38,6 +38,9 @@ quotes = [
           </li>
           <li class='<%= active_if_on('/filters') %>'>
             <a href="/filters">Filters</a>
+          </li>
+          <li class='<%= active_if_on('/sets') %>'>
+            <a href="/sets">Suggested Sets</a>
           </li>
         </ul>
         <ul class="nav navbar-nav navbar-right">
@@ -78,8 +81,8 @@ quotes = [
   </div>
   <script src="//code.jquery.com/jquery.js"></script>
   <!-- Include all compiled plugins (below), or include individual files as needed -->
-  <script src="js/bootstrap.min.js"></script>
-  <script src="js/gaps.js"></script>
+  <script src="/js/bootstrap.min.js"></script>
+  <script src="/js/gaps.js"></script>
   <script>
     window.CSRF = '<%== csrf_token %>';
     $('.dropdown-toggle').dropdown();

--- a/views/set.erb
+++ b/views/set.erb
@@ -1,0 +1,24 @@
+<div class="well">
+<p> You are editing a set of recommended groups. </p>
+</div>
+
+  <form method="POST" action="/sets/<%= @set ? @set._id : 'new' %>">
+  <%== csrf_tag %>
+
+<p> List name: <input type="text" name="name" value="<%= @set ? @set.name : '' %>" /> </p>
+
+<p> List description: <input type="text" name="description" value="<%= @set ? @set.description : '' %>" /> </p>
+
+<p> <input type="submit" value="Submit changes" /> </p>
+
+<%== erb :_category_list, :locals => {:groups => @groups} %>
+
+<div id="categories">
+  <% @groups.each do |category, groups| %>
+    <%== erb :_category, :locals => {:category => category, :groups => groups, :group_partial => group_partial} %>
+  <% end %>
+</div>
+
+<p> <input type="submit" value="Submit changes" /> </p>
+  </form>
+</div>

--- a/views/sets.erb
+++ b/views/sets.erb
@@ -1,5 +1,8 @@
 <div class="well">
-<p> These are recommended sets of groups you can subscribe yourself to, in order to make initial setup easier. </p>
+<p>
+  These are recommended sets of groups you can subscribe yourself to, in order to make initial setup easier.
+  If a set changes we will email you, we will not automatically subscribe you to lists.
+</p>
 
 </div>
 
@@ -19,7 +22,12 @@
             </li>
           </ul>
         </div>
-        <h4 class="list-group-item-heading"><%= set.name %></h4>
+        <h4 class="list-group-item-heading">
+          <%= set.name %>
+          <% if @user.sets.include?(set._id) %>
+            <span class="label label-primary">subscribed to set changes</span>
+          <% end %>
+        </h4>
         <p class="list-group-item-text"><%= set.description %></p>
         <p class="list-group-item-text"><%= set.groups_.map(&:group_email).join(', ') %></p>
         <form method="POST" action="/sets">

--- a/views/sets.erb
+++ b/views/sets.erb
@@ -1,0 +1,35 @@
+<div class="well">
+<p> These are recommended sets of groups you can subscribe yourself to, in order to make initial setup easier. </p>
+
+</div>
+
+<div id="categories">
+  <% @sets.each do |set| %>
+    <div class="panel panel-default">
+      <div class="panel-body">
+        <div class="btn-group pull-right move-dropdown">
+          <button type="button" class="btn btn-xs dropdown-toggle" data-toggle="dropdown"><span class="glyphicon glyphicon-cog"></span></button>
+          <ul class="dropdown-menu" role="menu">
+            <li>
+              <span class="input-group">
+                <span class="input-group-addon">
+                  <a href="/sets/<%= set._id %>">Edit Set</a>
+                </span>
+              </span>
+            </li>
+          </ul>
+        </div>
+        <h4 class="list-group-item-heading"><%= set.name %></h4>
+        <p class="list-group-item-text"><%= set.description %></p>
+        <p class="list-group-item-text"><%= set.groups_.map(&:group_email).join(', ') %></p>
+        <form method="POST" action="/sets">
+          <%== csrf_tag %>
+          <input type="hidden" name="set" value="<%= set._id %>" />
+          <p> <input type="submit" value="Add me to these groups" /> </p>
+        </form>
+      </div>
+    </div>
+  <% end %>
+</div>
+
+<p> <a href="/sets/new">Create a new set</a> </p>

--- a/views/subs.erb
+++ b/views/subs.erb
@@ -8,6 +8,8 @@ updated within 10 minutes and an automated email sent to <%= configatron.notify.
 
 <%== erb :_category_list, :locals => {:groups => @groups} %>
 
+<p> You are a member of <b><%= @user.group_member_count %></b> <%= @user.group_member_count == 1 ? 'group' : 'groups' %>. </p>
+
   <form method="POST" action="/subs">
   <%== csrf_tag %>
 <p> <input type="submit" value="Submit changes" /> </p>


### PR DESCRIPTION
Create configurable lists of groups that one can add themselves to. This avoids someone needing to sit behind you on your first day while you click 10 checkboxes.

Example sets I foresee:
* Remotes
* Engineers
* Product Org
* Support

r? @antifuchs 
CC @LachyGroom 

![screen shot 2015-11-27 at 4 46 18 pm](https://cloud.githubusercontent.com/assets/364070/11449361/817b21c6-9526-11e5-8d37-bc2c56ebc209.png)
![screen shot 2015-11-27 at 4 46 39 pm](https://cloud.githubusercontent.com/assets/364070/11449362/819f1630-9526-11e5-9bae-081def83af48.png)
