### PR TITLE
Fix Mongo connection pool size to match thread pool size

### DIFF
--- a/lib/gaps/db.rb
+++ b/lib/gaps/db.rb
@@ -7,7 +7,10 @@ module Gaps
 
     def self.init
       MongoMapper.database = configatron.db.database
-      MongoMapper.connection = Mongo::MongoClient.from_uri(configatron.db.mongodb_url, pool_size: 5)
+      MongoMapper.connection = Mongo::MongoClient.from_uri(
+        configatron.db.mongodb_url,
+        pool_size: [configatron.cache.pool_size, 5].max
+      )
 
       Cache.build_index
       Group.build_index


### PR DESCRIPTION
Currently, when using the thread pool to load groups, some threads may be starved of db connection.