### PR TITLE
Add opensearch.xml to search groups archive

### DIFF
--- a/bin/gaps_server.rb
+++ b/bin/gaps_server.rb
@@ -77,6 +77,11 @@ module Gaps
       redirect '/subs'
     end
 
+    get '/opensearch.xml' do
+      content_type :xml
+      erb :opensearch, layout: nil
+    end
+
     get '/status', auth: false do
       if logged_in?
         status 200

--- a/views/opensearch.erb
+++ b/views/opensearch.erb
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>Gaps</ShortName>
+  <Description>Google Groups archive search</Description>
+  <Url type="text/html"
+       method="get"
+       template="https://groups.google.com/a/<%= configatron.info.domain %>/forum/?fromgroups#!topicsearch/{searchTerms}" />
+</OpenSearchDescription>


### PR DESCRIPTION
This allows searching the Google Groups email archive via OpenSearch in supported browsers (Chrome, Firefox, [etc.](http://www.opensearch.org/Community/OpenSearch_search_clients)).

For example, if your configured Gaps application domain is `gaps.example.com`, you could type `gaps<tab>` into Chrome's address bar and then a query to search your configured Google Apps domain's Groups archive.