### PR TITLE
Add Docker Compose support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM phusion/passenger-ruby21
 MAINTAINER Greg Brockman <gdb@stripe.com>
 ENV PORT 3500
 EXPOSE 3500
+ADD Gemfile* /gaps/
+RUN cd /gaps && bundle install --path vendor/bundle
 ADD . /gaps
 # If you're running a version of docker before .dockerignore
 RUN rm -f /gaps/site.yaml*
@@ -9,6 +11,5 @@ RUN chown -R app: /gaps
 USER app
 ENV HOME /home/app
 ENV RACK_ENV production
-RUN cd /gaps && bundle install --path vendor/bundle
 WORKDIR /gaps
 CMD ["bin/hk-runner"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM phusion/passenger-ruby21
 MAINTAINER Greg Brockman <gdb@stripe.com>
+ENV PORT 3500
+EXPOSE 3500
 ADD . /gaps
 # If you're running a version of docker before .dockerignore
 RUN rm -f /gaps/site.yaml*
 RUN chown -R app: /gaps
 USER app
 ENV HOME /home/app
+ENV RACK_ENV production
 RUN cd /gaps && bundle install --path vendor/bundle
 WORKDIR /gaps
-CMD ["bin/gaps_server.rb"]
+CMD ["bin/hk-runner"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby '2.1.5'
+ruby '2.1.7'
 
 # Execute bundler hook (analogous to sourcing a dotfile)
 ['~/.', '/etc/'].any? do |file|

--- a/README.md
+++ b/README.md
@@ -76,10 +76,22 @@ Just click here: [![Deploy](https://www.herokucdn.com/deploy/button.png)](https:
 
 ## Running under Docker
 
-Because there are a lot of settings, running under Docker requires a
-configuration file. Clone this repository and execute
-`bin/docker-runner` to run the Docker image we've published with your
-`site.yaml` bind-mounted inside.
+First, you need to configure Gaps by creating a `.env` file and filling in your configuration:
+
+    ORG_DOMAIN=
+    ORG_NAME=
+    OAUTH_CLIENT_ID=
+    OAUTH_CLIENT_SECRET=
+    OAUTH_REDIRECT_URL=
+    SESSION_SECRET=
+
+To run a local development environment, you can use Docker Compose:
+
+    $ docker-compose up
+
+To run in production, you can just run the image on Docker Hub:
+
+    $ docker run -p 80:3500 --env-file=.env stripeoss/gaps
 
 # Permissions
 

--- a/bin/docker-runner
+++ b/bin/docker-runner
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-cd "$(dirname "$0")/.."
-sudo docker run -ti -e RACK_ENV=production -p 3500:3500 -v $(pwd)/site.yaml:/gaps/site.yaml:ro stripeoss/gaps $@

--- a/bin/hk-runner
+++ b/bin/hk-runner
@@ -43,6 +43,11 @@ port: $PORT
 session:
   secret: $SESSION_SECRET
   secure: true
+
+permissions:
+  privacy_settings:
+    gaps_scheme: ${PRIVACY_GAPS_SCHEME:-true}
+    api_scheme: ${PRIVACY_API_SCHEME:-false}
 EOF
 
 exec bundle exec bin/gaps_server.rb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '2'
+services:
+  web:
+    build: .
+    ports:
+      - 3500:3500
+    links:
+      - mongo
+    environment:
+      - MONGODB_URL=mongodb://mongo/mongo
+      - RACK_ENV=development
+      - FAVICON_URL=
+      - GAPS_URL=
+      - ORG_DOMAIN=
+      - ORG_NAME=
+      - OAUTH_CLIENT_ID=
+      - OAUTH_CLIENT_SECRET=
+      - OAUTH_REDIRECT_URL=
+      - SESSION_SECRET=
+  mongo:
+    image: mongo


### PR DESCRIPTION
 - Add support for running development environments with Docker Compose.
 - Configure the Docker image with environment variables, like is done on Heroku.

This is an improved version of #15. /cc @antifuchs :)